### PR TITLE
added themeStyle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -284,6 +284,9 @@ const flattenStyle = (message: Message): StyleById => {
       };
     });
   }, {});
+
+  styleById['themeStyle'] = message.config.themeStyle;
+
   return styleById;
 };
 


### PR DESCRIPTION
We don't currently pass through theme/style defaults. This would be useful to developers trying to follow an existing palette.

Ref [StackOverflow post](https://stackoverflow.com/questions/54964505/can-datastudio-community-visualizations-access-a-chart-palette)